### PR TITLE
fix(actions): repair workflow validator indentation

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   go-contract:

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -73,17 +73,17 @@ jobs:
                               if typ not in valid_input_types:
                                   bad.append(f"{file}: input '{name}' has invalid type '{typ}'")
 
-               jobs = (data or {}).get("jobs", {})
-               if file.name == "node-ci.yml":
-                   node_ci = jobs.get("ci", {})
-                   permissions = node_ci.get("permissions", {})
-                   if permissions.get("packages") != "read":
-                       bad.append(
-                           f"{file}: reusable node-ci job must declare permissions.packages=read"
-                       )
-               for job_name, job in jobs.items():
-                   for idx, step in enumerate(job.get("steps", []), start=1):
-                       uses = step.get("uses")
+              jobs = (data or {}).get("jobs", {})
+              if file.name == "node-ci.yml":
+                  node_ci = jobs.get("ci", {})
+                  permissions = node_ci.get("permissions", {})
+                  if permissions.get("packages") != "read":
+                      bad.append(
+                          f"{file}: reusable node-ci job must declare permissions.packages=read"
+                      )
+              for job_name, job in jobs.items():
+                  for idx, step in enumerate(job.get("steps", []), start=1):
+                      uses = step.get("uses")
                       if not uses or uses.startswith("./") or uses.startswith("docker://"):
                           continue
                       if not uses_sha.match(uses):


### PR DESCRIPTION
## Summary\n- fix the embedded Python indentation in validate-workflows.yml\n- keep the new node-ci packages: read assertion intact\n- grant contract-tests.yml caller-side packages: read so local node-ci reusable jobs can start\n\n## Validation\n- python -m pip install --disable-pip-version-check --quiet pyyaml\n- run the inline validator from .github/workflows/validate-workflows.yml\n- cd fixtures/node && npm ci --no-audit --no-fund && npm test