### PR TITLE
feat(ci): cache pnpm, npm, Go, and Playwright artefacts

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,5 +1,10 @@
 {
   "entries": {
+    "actions/cache@v5": {
+      "repo": "actions/cache",
+      "version": "v5",
+      "sha": "27d5ce7f107fe9357f9df03efb73ab90386fccae"
+    },
     "actions/checkout@v6.0.2": {
       "repo": "actions/checkout",
       "version": "v6.0.2",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,53 @@ jobs:
       - name: Install configured tools
         run: mise install
 
+      # Caches restore before `mise run install` ships the package modules /
+      # Playwright browsers; actions/cache auto-saves at job end. Each step
+      # is gated on its lockfile so a Go repo never caches pnpm and vice versa.
+      - name: Cache pnpm store
+        if: ${{ hashFiles('pnpm-lock.yaml') != '' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.cache/pnpm
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Cache npm cache
+        if: ${{ hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+
+      - name: Cache Go modules and build cache
+        if: ${{ hashFiles('go.mod') != '' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
+          restore-keys: |
+            go-${{ runner.os }}-
+
+      - name: Cache Playwright browser binaries
+        # Restored before `mise run install` (which installs browsers) and
+        # saved after the install task populates them. Keyed by runner OS so
+        # Linux/mac binaries never cross-contaminate. Skipped for repos with
+        # no Playwright config.
+        if: ${{ hashFiles('**/playwright.config.ts', '**/playwright.config.js') != '' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/playwright.config.ts', '**/playwright.config.js') }}-v1
+
       - name: Export task environment
         if: ${{ inputs.task-env != '' }}
         env:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ jobs:
 
 This workflow runs `mise run install`, `lint`, `build`, `test`, `vet`, and `fmt` when the matching boolean input is `true`. Use `task-prefix` only when a repository namespaces tasks, for example `task-prefix: "go-"` to run `go-test`, `go-vet`, and `go-fmt`. Use `task-env` for multiline task configuration such as working directories or command overrides. Repositories should declare any required runtimes or tools through `mise.toml` or `.tool-versions` so the workflow can provision them consistently.
 
+The workflow restores and saves dependency caches keyed by lockfile hash before running the install task: the pnpm store (when `pnpm-lock.yaml` is present), the npm cache (when `package-lock.json` is present and no pnpm lockfile is), Go modules plus the Go build cache (when `go.mod` is present), and Playwright browser binaries (when a `playwright.config.ts` or `playwright.config.js` exists). Each cache is scoped to `runner.os` so Linux and macOS runner binaries never cross-contaminate. Caches auto-restore at job start (falling through cleanly on a miss) and auto-save at job end.
+
 Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
 
 ### Go CI


### PR DESCRIPTION
## Summary

Adds dependency-artefact caching to the universal `ci.yml` (`workflow_call`), so consumers stop re-downloading pnpm/npm/go/playwright on every run. Restores happen after `mise install` and before the `mise run install` task; `actions/cache` auto-saves at job end. On a cache miss the step falls through cleanly — install is idempotent, so a bad key never breaks CI.

## What's cached

| Cache | Condition (lockfile present) | Path |
|---|---|---|
| pnpm store | `pnpm-lock.yaml` | `~/.local/share/pnpm/store`, `~/.cache/pnpm` |
| npm cache | `package-lock.json` (and no pnpm lockfile) | `~/.npm` |
| Go modules + build cache | `go.mod` | `~/go/pkg/mod`, `~/.cache/go-build` |
| Playwright browser binaries | any `playwright.config.ts`/`.js` | `~/.cache/ms-playwright`, `~/Library/Caches/ms-playwright` |

## Design notes

- **Lockfile-gated:** each `if:` checks `hashFiles('<lockfile>') != ''`, so a Go repo never runs the pnpm step and a non-Playwright repo skips the browser cache. The npm step additionally guards against `pnpm-lock.yaml` to avoid double-caching repos that carry both.
- **OS-scoped keys:** every key includes `${{ runner.os }}` so Linux/macOS binaries can't cross-contaminate.
- **SHA-pinned:** `actions/cache@v5` pinned to `27d5ce7f107fe9357f9df03efb73ab90386fccae`, satisfying the repo's `validate-workflows.yml` pin policy (verified locally: 19 files, all pinned + valid).
- **Provenance:** `actions-lock.json` ledger updated; README documents the behaviour.

## Proof

- `contract-tests.yml` invokes `ci.yml` against the `fixtures/go` (go.mod → Go cache), `fixtures/node` (package-lock.json → npm cache), and `fixtures/bun` (no lockfile → no cache step) fixtures on every PR to this repo — so the contract jobs in this PR are the real validation of the new cache code paths.
- Local YAML + SHA-pin validation: **OK, 19 files.**

## What this does NOT do

This PR does not cut a release tag. Downstream consumers pin to a ref (`@<sha> # v2`) — the caches only apply to a consumer's runs after this lands on the tagged line and each consumer bumps its ref. Tagging a release is left as a separate decision.
