### PR TITLE
chore: audit fixes — remove stale docs, fix concurrency groups, add working-directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ on:
         required: false
         default: ''
         type: string
+      working-directory:
+        description: 'Working directory for run steps. Note: the mise tasks handle working directories through task-env (e.g. MISE_GO_WORKING_DIR). This input exists for backwards compatibility with callers that pass it.'
+        required: false
+        default: '.'
+        type: string
 
 jobs:
   ci:
@@ -82,9 +87,6 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
-
-      - name: Install configured tools
-        run: mise install
 
       # Caches restore before `mise run install` ships the package modules /
       # Playwright browsers; actions/cache auto-saves at job end. Each step

--- a/.github/workflows/docker-ghcr-publish.yml
+++ b/.github/workflows/docker-ghcr-publish.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
-      group: ${{ format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) }}
+      group: ${{ inputs.concurrency-suffix != '' && format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) || format('{0}:{1}:{2}', github.workflow, github.repository, github.ref) }}
       cancel-in-progress: ${{ inputs.cancel-in-progress }}
     permissions:
       contents: read

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
-      group: ${{ format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) }}
+      group: ${{ inputs.concurrency-suffix != '' && format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) || format('{0}:{1}:{2}', github.workflow, github.repository, github.ref) }}
       cancel-in-progress: ${{ inputs.cancel-in-progress }}
     permissions:
       contents: read

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
-      group: ${{ format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) }}
+      group: ${{ inputs.concurrency-suffix != '' && format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) || format('{0}:{1}:{2}', github.workflow, github.repository, github.ref) }}
       cancel-in-progress: ${{ inputs.cancel-in-progress }}
     permissions:
       contents: read

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -74,7 +74,7 @@ jobs:
                                   bad.append(f"{file}: input '{name}' has invalid type '{typ}'")
 
               jobs = (data or {}).get("jobs", {})
-              if file.name in {"node-ci.yml", "aube-ci.yml"}:
+              if file.name in {"aube-ci.yml"}:
                   ci_job = jobs.get("ci", {})
                   permissions = ci_job.get("permissions", {})
                   if permissions.get("packages") != "read":

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
       timeout-minutes: 15
       cancel-in-progress: false
       concurrency-suffix: ""
+      working-directory: "."
 ```
 
 This workflow runs `mise run install`, `lint`, `build`, `test`, `vet`, and `fmt` when the matching boolean input is `true`. Use `task-prefix` only when a repository namespaces tasks, for example `task-prefix: "go-"` to run `go-test`, `go-vet`, and `go-fmt`. Use `task-env` for multiline task configuration such as working directories or command overrides. Repositories should declare any required runtimes or tools through `mise.toml` or `.tool-versions` so the workflow can provision them consistently.
@@ -38,34 +39,6 @@ This workflow runs `mise run install`, `lint`, `build`, `test`, `vet`, and `fmt`
 The workflow restores and saves dependency caches keyed by lockfile hash before running the install task: the pnpm store (when `pnpm-lock.yaml` is present), the npm cache (when `package-lock.json` is present and no pnpm lockfile is), Go modules plus the Go build cache (when `go.mod` is present), and Playwright browser binaries (when a `playwright.config.ts` or `playwright.config.js` exists). Each cache is scoped to `runner.os` so Linux and macOS runner binaries never cross-contaminate. Caches auto-restore at job start (falling through cleanly on a miss) and auto-save at job end.
 
 Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
-
-### Go CI
-
-```yaml
-jobs:
-  ci:
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@v1
-    with:
-      runner: ubuntu-latest
-      go-version-file: go.mod
-      working-directory: .
-      run-test: true
-      run-race: false
-      run-vet: true
-      run-fmt: false
-      test-args: ""
-      test-command: ""
-      build-command: ""
-      coverage-path: ""
-      coverage-artifact-name: ""
-      timeout-minutes: 15
-      cancel-in-progress: false
-      concurrency-suffix: ""
-```
-
-Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
-
-Use `run-test: false` for build-only or format-only invocations, `build-command` for an explicit build step, `test-command` when the default `go test ./...` contract is not enough, and `coverage-path` + `coverage-artifact-name` to publish coverage output for downstream jobs such as Codecov uploads. When `test-command` is set, the workflow does not apply `test-args` or `run-race` automatically; include any desired extra args or race flags directly in the custom command. `coverage-path` and `coverage-artifact-name` must be set together; providing only one is treated as an invalid configuration.
 
 ### Go Lint
 
@@ -83,35 +56,6 @@ jobs:
       timeout-minutes: 15
       cancel-in-progress: false
 ```
-
-### Node CI
-
-```yaml
-jobs:
-  ci:
-    uses: matt-riley/matt-riley-ci/.github/workflows/node-ci.yml@v1
-    with:
-      node-version: "22"
-      runner: ubuntu-latest
-      package-manager: pnpm
-      pnpm-version: ""
-      working-directory: .
-      cache-dependency-path: ""
-      require-lockfile: false
-      install-command: ""
-      run-lint: true
-      run-test: true
-      run-build: false
-      test-script: test
-      verify-lockfile-clean: false
-      lockfile-path: ""
-      build-env: ""
-      timeout-minutes: 15
-      cancel-in-progress: false
-      concurrency-suffix: ""
-```
-
-Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
 
 ### Aube CI
 
@@ -141,24 +85,6 @@ jobs:
 Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
 
 Aube reads supported lockfiles in place (`aube-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`). If a repository contains more than one supported lockfile, set `lockfile-path` explicitly so the workflow can validate and diff the intended file.
-
-### Bun CI
-
-```yaml
-jobs:
-  ci:
-    uses: matt-riley/matt-riley-ci/.github/workflows/bun-ci.yml@v1
-    with:
-      bun-version: latest
-      runner: ubuntu-latest
-      working-directory: .
-      frozen-lockfile: true
-      require-lockfile: false
-      run-lint: false
-      run-test: true
-      timeout-minutes: 15
-      cancel-in-progress: false
-```
 
 ### Cloudflare Pages Deploy
 


### PR DESCRIPTION
## What

Audit fixes for matt-riley-ci addressing stale documentation, concurrency group consistency, and backwards compatibility.

## Changes

- **README**: Removed Go CI, Node CI, and Bun CI sections (deleted in v2.0.0). Added working-directory to Universal CI example.
- **ci.yml**: Added working-directory input for backwards compat with callers. Removed redundant mise install step (mise-action already runs it).
- **docker-ghcr-publish.yml, go-lint.yml, go-security.yml**: Ported conditional concurrency group format matching ci.yml.
- **validate-workflows.yml**: Dropped stale node-ci.yml check.

**6 files, +10/−82**