### PR TITLE
fix: add cache-dependency-path for mono-repo go.mod support

### DIFF
--- a/.github/workflows/go-goreleaser.yml
+++ b/.github/workflows/go-goreleaser.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           go-version-file: ${{ inputs.go-version-file }}
           cache: true
+          cache-dependency-path: ${{ inputs.go-version-file }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           go-version-file: ${{ inputs.go-version-file }}
           cache: true
+          cache-dependency-path: ${{ inputs.go-version-file }}
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           go-version-file: ${{ inputs.go-version-file }}
           cache: true
+          cache-dependency-path: ${{ inputs.go-version-file }}
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}


### PR DESCRIPTION
## Problem

When consuming workflows pass `go-version-file` pointing to a subdirectory (e.g. `services/api/go.mod`), `actions/setup-go` cache feature cannot find `go.mod` at the repo root and silently skips caching:

```
##[warning]Restore cache failed: Dependencies file is not found in /home/runner/work/workv2/workv2. Supported file pattern: go.mod
```

This was observed in the `workv2` repo where both govulncheck jobs use `go-version-file: services/api/go.mod` and `services/tui/go.mod`.

## Fix

Add `cache-dependency-path` to the `actions/setup-go` step in all three reusable Go workflows:
- `go-security.yml`
- `go-lint.yml`
- `go-goreleaser.yml`

This tells setup-go where to look for the go.mod file for cache key generation, enabling the module cache to work correctly in mono-repo layouts.

## Test plan
- [ ] Verify CI runs show cache restoration (no warning) on workv2 after merge