### PR TITLE
fix: release immutable infra artifact handoff

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -19,6 +19,26 @@ permissions:
   packages: read
 
 jobs:
+  infra-deploy-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.x"
+
+      - name: Install contract dependencies
+        run: python -m pip install --disable-pip-version-check --quiet pyyaml
+
+      - name: Test infra deploy contracts
+        run: |
+          python -m unittest tests/request_infra_deploy_contract_test.py
+          python -m unittest tests/contract_workflow_registration_test.py
+
   go-contract:
     uses: ./.github/workflows/ci.yml
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .fallow/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Dispatches `deploy-app` to the infra repository so the centralized infra workflo
 ```yaml
 jobs:
   request-deploy:
-    uses: matt-riley/matt-riley-ci/.github/workflows/request-infra-deploy.yml@v1
+    uses: matt-riley/matt-riley-ci/.github/workflows/request-infra-deploy.yml@v2
     with:
       app-name: my-app
       infra-repo: infra
@@ -131,7 +131,7 @@ For an immutable artifact deployment, make the caller wait for its artifact job 
 jobs:
   request-deploy:
     needs: build
-    uses: matt-riley/matt-riley-ci/.github/workflows/request-infra-deploy.yml@v1
+    uses: matt-riley/matt-riley-ci/.github/workflows/request-infra-deploy.yml@v2
     with:
       app-name: my-app
       infra-repo: infra

--- a/tests/contract_workflow_registration_test.py
+++ b/tests/contract_workflow_registration_test.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import unittest
+
+
+class ContractWorkflowRegistrationTest(unittest.TestCase):
+    def test_contract_workflow_runs_infra_deploy_contracts(self):
+        workflow = Path(".github/workflows/contract-tests.yml").read_text()
+
+        self.assertIn("tests/request_infra_deploy_contract_test.py", workflow)
+        self.assertIn("tests/contract_workflow_registration_test.py", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- register immutable artifact contract tests in shared CI
- document the supported v2 reusable workflow reference
- keep artifact handoff generic and provider-blind

## Verification

- python -m unittest discover -s tests -p "*test.py"
- actionlint .github/workflows/contract-tests.yml
- git diff --check

Waffle will consume this contract only after the reviewed v2 release is available.