### PR TITLE
fix: refresh Go caches from trusted main runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,16 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4
         with:
-          cache_save: ${{ inputs.save-cache && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          cache_save: ${{ inputs.save-cache && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       # Caches restore before `mise run install` ships the package modules /
-      # Playwright browsers; actions/cache auto-saves at job end. Each step
-      # is gated on its lockfile so a Go repo never caches pnpm and vice versa.
-      - name: Cache pnpm store
+      # Playwright browsers. Each step is gated on its lockfile so a Go repo
+      # never caches pnpm and vice versa. Only an opted-in trusted default-
+      # branch run saves updated entries after every requested task succeeds.
+      - name: Restore pnpm store
+        id: restore-pnpm
         if: ${{ hashFiles('pnpm-lock.yaml') != '' }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.local/share/pnpm/store
@@ -109,9 +111,10 @@ jobs:
           restore-keys: |
             pnpm-${{ runner.os }}-
 
-      - name: Cache npm cache
+      - name: Restore npm cache
+        id: restore-npm
         if: ${{ hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -149,13 +152,14 @@ jobs:
           restore-keys: |
             go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-
 
-      - name: Cache Playwright browser binaries
+      - name: Restore Playwright browser binaries
+        id: restore-playwright
         # Restored before `mise run install` (which installs browsers) and
-        # saved after the install task populates them. Keyed by runner OS so
-        # Linux/mac binaries never cross-contaminate. Skipped for repos with
-        # no Playwright config.
+        # saved only by an opted-in trusted run after the install task
+        # populates them. Keyed by runner OS so Linux/mac binaries never
+        # cross-contaminate. Skipped for repos with no Playwright config.
         if: ${{ hashFiles('**/playwright.config.ts', '**/playwright.config.js') != '' }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cache/ms-playwright
@@ -200,19 +204,44 @@ jobs:
         if: ${{ inputs.fmt }}
         run: mise run "${{ inputs.task-prefix }}fmt"
 
+      - name: Save pnpm store
+        if: ${{ success() && inputs.save-cache && hashFiles('pnpm-lock.yaml') != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-pnpm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.cache/pnpm
+          key: ${{ steps.restore-pnpm.outputs.cache-primary-key }}
+
+      - name: Save npm cache
+        if: ${{ success() && inputs.save-cache && hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-npm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.npm
+          key: ${{ steps.restore-npm.outputs.cache-primary-key }}
+
       - name: Save Go module cache
-        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-modules.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-modules.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ steps.go-cache-metadata.outputs.module_cache }}
           key: ${{ steps.restore-go-modules.outputs.cache-primary-key }}
 
       - name: Save Go build cache
-        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-build.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-build.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ steps.go-cache-metadata.outputs.build_cache }}
           key: ${{ steps.restore-go-build.outputs.cache-primary-key }}
+
+      - name: Save Playwright browser binaries
+        if: ${{ success() && inputs.save-cache && hashFiles('**/playwright.config.ts', '**/playwright.config.js') != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-playwright.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: ${{ steps.restore-playwright.outputs.cache-primary-key }}
 
       - name: Summary
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: false
         type: boolean
+      save-cache:
+        description: 'Save dependency and build caches after a successful run'
+        required: false
+        default: false
+        type: boolean
       task-prefix:
         description: 'Optional prefix added before standard task names (for example "go-" -> "go-test")'
         required: false
@@ -87,6 +92,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4
+        with:
+          cache_save: ${{ inputs.save-cache && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       # Caches restore before `mise run install` ships the package modules /
       # Playwright browsers; actions/cache auto-saves at job end. Each step
@@ -111,16 +118,36 @@ jobs:
           restore-keys: |
             npm-${{ runner.os }}-
 
-      - name: Cache Go modules and build cache
+      - name: Detect Go cache metadata
+        id: go-cache-metadata
         if: ${{ hashFiles('go.mod') != '' }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        shell: bash
+        run: |
+          {
+            echo "version=$(go env GOVERSION)"
+            echo "module_cache=$(go env GOMODCACHE)"
+            echo "build_cache=$(go env GOCACHE)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: restore-go-modules
+        if: ${{ hashFiles('go.mod') != '' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
+          path: ${{ steps.go-cache-metadata.outputs.module_cache }}
+          key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
           restore-keys: |
-            go-${{ runner.os }}-
+            go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-
+
+      - name: Restore Go build cache
+        id: restore-go-build
+        if: ${{ hashFiles('go.mod') != '' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.build_cache }}
+          key: go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-
 
       - name: Cache Playwright browser binaries
         # Restored before `mise run install` (which installs browsers) and
@@ -173,6 +200,20 @@ jobs:
         if: ${{ inputs.fmt }}
         run: mise run "${{ inputs.task-prefix }}fmt"
 
+      - name: Save Go module cache
+        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-modules.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.module_cache }}
+          key: ${{ steps.restore-go-modules.outputs.cache-primary-key }}
+
+      - name: Save Go build cache
+        if: ${{ success() && inputs.save-cache && hashFiles('go.mod') != '' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.restore-go-build.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.build_cache }}
+          key: ${{ steps.restore-go-build.outputs.cache-primary-key }}
+
       - name: Summary
         if: ${{ always() }}
         run: |
@@ -188,4 +229,7 @@ jobs:
             echo "- test: \`${{ inputs.test }}\`"
             echo "- vet: \`${{ inputs.vet }}\`"
             echo "- fmt: \`${{ inputs.fmt }}\`"
+            echo "- save-cache: \`${{ inputs.save-cache }}\`"
+            echo "- Go module cache: \`${{ steps.restore-go-modules.outputs.cache-matched-key || 'not used' }}\`"
+            echo "- Go build cache: \`${{ steps.restore-go-build.outputs.cache-matched-key || 'not used' }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m unittest tests/request_infra_deploy_contract_test.py
           python -m unittest tests/contract_workflow_registration_test.py
+          python -m unittest tests/ci_cache_contract_test.py
 
   go-contract:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -66,8 +66,33 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: ${{ inputs.go-version-file }}
-          cache: true
-          cache-dependency-path: ${{ inputs.go-version-file }}
+          cache: false
+
+      - name: Detect Go cache metadata
+        id: go-cache-metadata
+        shell: bash
+        run: |
+          {
+            echo "version=$(go env GOVERSION)"
+            echo "module_cache=$(go env GOMODCACHE)"
+            echo "build_cache=$(go env GOCACHE)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.module_cache }}
+          key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-
+
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.build_cache }}
+          key: go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
@@ -75,6 +100,7 @@ jobs:
           version: ${{ inputs.golangci-version }}
           args: ${{ inputs.golangci-args }}
           working-directory: ${{ inputs.working-directory }}
+          skip-save-cache: ${{ !((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
         continue-on-error: ${{ inputs.continue-on-error }}
 
       - name: Summary

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -56,8 +56,33 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: ${{ inputs.go-version-file }}
-          cache: true
-          cache-dependency-path: ${{ inputs.go-version-file }}
+          cache: false
+
+      - name: Detect Go cache metadata
+        id: go-cache-metadata
+        shell: bash
+        run: |
+          {
+            echo "version=$(go env GOVERSION)"
+            echo "module_cache=$(go env GOMODCACHE)"
+            echo "build_cache=$(go env GOCACHE)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.module_cache }}
+          key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-
+
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.go-cache-metadata.outputs.build_cache }}
+          key: go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}-
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This workflow runs `mise run install`, `lint`, `build`, `test`, `vet`, and `fmt`
 
 The workflow restores dependency caches before running tasks. For Go repositories, modules and build outputs have separate lifecycles: the module cache is keyed by dependency files, while the build cache restores the newest compatible snapshot and uses the commit SHA for each new snapshot. Both keys include the runner OS, architecture, and installed Go version.
 
-Go and mise cache writes are disabled by default. Set `save-cache: true` on exactly one comprehensive caller job; the workflow still refuses to write those caches for pull requests or non-default branches. A successful default-branch run then seeds caches that later pull requests can restore. Other dependency caches retain their existing lockfile-based behavior.
+Cache writes are disabled by default. Set `save-cache: true` on exactly one comprehensive caller job; the workflow still refuses to write for pull requests, pull-request-target workflows, or non-default branches. A successful default-branch push or manual run then seeds mise, lockfile dependency, Go, and Playwright caches that later pull requests can restore.
 
 Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ jobs:
       cancel-in-progress: false
       concurrency-suffix: ""
       working-directory: "."
+      save-cache: false
 ```
 
 This workflow runs `mise run install`, `lint`, `build`, `test`, `vet`, and `fmt` when the matching boolean input is `true`. Use `task-prefix` only when a repository namespaces tasks, for example `task-prefix: "go-"` to run `go-test`, `go-vet`, and `go-fmt`. Use `task-env` for multiline task configuration such as working directories or command overrides. Repositories should declare any required runtimes or tools through `mise.toml` or `.tool-versions` so the workflow can provision them consistently.
 
-The workflow restores and saves dependency caches keyed by lockfile hash before running the install task: the pnpm store (when `pnpm-lock.yaml` is present), the npm cache (when `package-lock.json` is present and no pnpm lockfile is), Go modules plus the Go build cache (when `go.mod` is present), and Playwright browser binaries (when a `playwright.config.ts` or `playwright.config.js` exists). Each cache is scoped to `runner.os` so Linux and macOS runner binaries never cross-contaminate. Caches auto-restore at job start (falling through cleanly on a miss) and auto-save at job end.
+The workflow restores dependency caches before running tasks. For Go repositories, modules and build outputs have separate lifecycles: the module cache is keyed by dependency files, while the build cache restores the newest compatible snapshot and uses the commit SHA for each new snapshot. Both keys include the runner OS, architecture, and installed Go version.
+
+Go and mise cache writes are disabled by default. Set `save-cache: true` on exactly one comprehensive caller job; the workflow still refuses to write those caches for pull requests or non-default branches. A successful default-branch run then seeds caches that later pull requests can restore. Other dependency caches retain their existing lockfile-based behavior.
 
 Set `concurrency-suffix` when invoking this workflow multiple times in the same workflow file to avoid concurrency group collisions between calls.
 

--- a/tests/ci_cache_contract_test.py
+++ b/tests/ci_cache_contract_test.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+class UniversalCiCacheContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = yaml.safe_load(
+            Path(".github/workflows/ci.yml").read_text()
+        )
+        cls.job = cls.workflow["jobs"]["ci"]
+        cls.steps = cls.job["steps"]
+        cls.steps_by_name = {
+            step["name"]: step for step in cls.steps if "name" in step
+        }
+
+    def test_cache_writes_require_explicit_opt_in(self):
+        trigger = self.workflow.get("on", self.workflow.get(True))
+        inputs = trigger["workflow_call"]["inputs"]
+        self.assertIn("save-cache", inputs)
+        save_cache = inputs["save-cache"]
+
+        self.assertEqual(
+            save_cache,
+            {
+                "description": "Save dependency and build caches after a successful run",
+                "required": False,
+                "default": False,
+                "type": "boolean",
+            },
+        )
+        self.assertEqual(
+            self.steps_by_name["Install mise"]["with"]["cache_save"],
+            "${{ inputs.save-cache && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}",
+        )
+
+        for name in ("Save Go module cache", "Save Go build cache"):
+            condition = self.steps_by_name[name]["if"]
+            self.assertIn("success()", condition)
+            self.assertIn("inputs.save-cache", condition)
+            self.assertIn("github.event_name != 'pull_request'", condition)
+            self.assertIn("github.event.repository.default_branch", condition)
+            self.assertIn("hashFiles('go.mod') != ''", condition)
+            self.assertIn("cache-hit != 'true'", condition)
+
+    def test_go_modules_and_build_outputs_use_separate_cache_lifecycles(self):
+        self.assertIn("Restore Go module cache", self.steps_by_name)
+        self.assertIn("Restore Go build cache", self.steps_by_name)
+        module_restore = self.steps_by_name["Restore Go module cache"]
+        build_restore = self.steps_by_name["Restore Go build cache"]
+
+        self.assertEqual(
+            module_restore["uses"],
+            "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+        )
+        self.assertEqual(
+            build_restore["uses"],
+            "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+        )
+
+        module_key = module_restore["with"]["key"]
+        build_key = build_restore["with"]["key"]
+        self.assertIn("go-mod-v2-", module_key)
+        self.assertIn("runner.arch", module_key)
+        self.assertIn("steps.go-cache-metadata.outputs.version", module_key)
+        self.assertIn("hashFiles('go.mod', 'go.sum')", module_key)
+        self.assertNotIn("github.sha", module_key)
+
+        self.assertIn("go-build-v2-", build_key)
+        self.assertIn("runner.arch", build_key)
+        self.assertIn("steps.go-cache-metadata.outputs.version", build_key)
+        self.assertIn("hashFiles('go.mod', 'go.sum')", build_key)
+        self.assertIn("github.sha", build_key)
+
+        self.assertEqual(
+            module_restore["with"]["path"],
+            "${{ steps.go-cache-metadata.outputs.module_cache }}",
+        )
+        self.assertEqual(
+            build_restore["with"]["path"],
+            "${{ steps.go-cache-metadata.outputs.build_cache }}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci_cache_contract_test.py
+++ b/tests/ci_cache_contract_test.py
@@ -103,6 +103,41 @@ class UniversalCiCacheContractTest(unittest.TestCase):
             "${{ steps.go-cache-metadata.outputs.build_cache }}",
         )
 
+    def test_specialized_go_workflows_restore_without_implicit_go_writes(self):
+        for path, job_name in (
+            (".github/workflows/go-lint.yml", "lint"),
+            (".github/workflows/go-security.yml", "govulncheck"),
+        ):
+            workflow = yaml.safe_load(Path(path).read_text())
+            steps = workflow["jobs"][job_name]["steps"]
+            steps_by_name = {
+                step["name"]: step for step in steps if "name" in step
+            }
+
+            self.assertIs(
+                steps_by_name["Set up Go"]["with"]["cache"],
+                False,
+            )
+            for name in ("Restore Go module cache", "Restore Go build cache"):
+                self.assertIn(name, steps_by_name)
+                self.assertEqual(
+                    steps_by_name[name]["uses"],
+                    "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+                )
+
+        lint = yaml.safe_load(
+            Path(".github/workflows/go-lint.yml").read_text()
+        )
+        lint_steps = {
+            step["name"]: step
+            for step in lint["jobs"]["lint"]["steps"]
+            if "name" in step
+        }
+        skip_save = lint_steps["Run golangci-lint"]["with"]["skip-save-cache"]
+        self.assertIn("github.event_name == 'push'", skip_save)
+        self.assertIn("github.event_name == 'workflow_dispatch'", skip_save)
+        self.assertIn("github.event.repository.default_branch", skip_save)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci_cache_contract_test.py
+++ b/tests/ci_cache_contract_test.py
@@ -33,17 +33,37 @@ class UniversalCiCacheContractTest(unittest.TestCase):
         )
         self.assertEqual(
             self.steps_by_name["Install mise"]["with"]["cache_save"],
-            "${{ inputs.save-cache && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}",
+            "${{ inputs.save-cache && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}",
         )
 
-        for name in ("Save Go module cache", "Save Go build cache"):
+        save_steps = (
+            "Save pnpm store",
+            "Save npm cache",
+            "Save Go module cache",
+            "Save Go build cache",
+            "Save Playwright browser binaries",
+        )
+        for name in save_steps:
             condition = self.steps_by_name[name]["if"]
             self.assertIn("success()", condition)
             self.assertIn("inputs.save-cache", condition)
-            self.assertIn("github.event_name != 'pull_request'", condition)
+            self.assertIn("github.event_name == 'push'", condition)
+            self.assertIn("github.event_name == 'workflow_dispatch'", condition)
+            self.assertNotIn("github.event_name != 'pull_request'", condition)
             self.assertIn("github.event.repository.default_branch", condition)
-            self.assertIn("hashFiles('go.mod') != ''", condition)
             self.assertIn("cache-hit != 'true'", condition)
+
+        for step in self.steps:
+            self.assertNotEqual(
+                step.get("uses"),
+                "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+            )
+
+        for name in ("Save Go module cache", "Save Go build cache"):
+            self.assertIn(
+                "hashFiles('go.mod') != ''",
+                self.steps_by_name[name]["if"],
+            )
 
     def test_go_modules_and_build_outputs_use_separate_cache_lifecycles(self):
         self.assertIn("Restore Go module cache", self.steps_by_name)

--- a/tests/contract_workflow_registration_test.py
+++ b/tests/contract_workflow_registration_test.py
@@ -8,6 +8,7 @@ class ContractWorkflowRegistrationTest(unittest.TestCase):
 
         self.assertIn("tests/request_infra_deploy_contract_test.py", workflow)
         self.assertIn("tests/contract_workflow_registration_test.py", workflow)
+        self.assertIn("tests/ci_cache_contract_test.py", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- split Go modules and Go build outputs into independent cache lifecycles
- restore the newest compatible build snapshot and save immutable per-commit snapshots
- require an explicit `save-cache` opt-in and enforce successful default-branch-only writes
- prevent pull requests and non-default branches from writing Go or mise caches
- expose matched cache keys in the job summary
- document the caller contract and add regression coverage for key and writer policy

## Why

The previous cache combined modules and build outputs under a `go.mod`-only immutable key. Once created, that snapshot could never refresh as source files changed, so Waffle was restoring an increasingly stale ~603 MiB cache while receiving progressively fewer Go test-cache hits.

This design makes one comprehensive default-branch job the canonical writer. Pull requests restore the latest compatible default-branch seed without creating merge-ref-only cache families.

## Compatibility

`save-cache` defaults to `false`, so existing callers remain restore-only until they explicitly nominate one trusted writer. A paired Waffle PR will pin this workflow commit and enable writes only for its comprehensive CI job.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/contract-tests.yml`
- `mise run ci`
- `python -m unittest discover -s tests -p '*_test.py'`
- `git diff --check`
