### PR TITLE
feat: add tailscale-acl reusable workflow

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -39,6 +39,7 @@ jobs:
           python -m unittest tests/request_infra_deploy_contract_test.py
           python -m unittest tests/contract_workflow_registration_test.py
           python -m unittest tests/ci_cache_contract_test.py
+          python -m unittest tests/tailscale_acl_contract_test.py
 
   go-contract:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/tailscale-acl.yml
+++ b/.github/workflows/tailscale-acl.yml
@@ -1,0 +1,132 @@
+name: Tailscale ACL
+
+# GitOps for a tailnet policy file: validate and run the policy's own ACL tests
+# on pull requests, apply on merge to the default branch.
+#
+# Authentication is workload identity federation, so this workflow takes no
+# secrets at all. The client ID and audience are not sensitive, so callers pass
+# them as plain inputs; the runner mints its own OIDC token, which Tailscale
+# exchanges for a short-lived API token. Callers only need `id-token: write`.
+#
+# Policy files contain user and group identifiers, so the calling repository
+# should be private.
+
+on:
+  workflow_call:
+    inputs:
+      tailnet:
+        description: "Tailnet name, or '-' for the default tailnet of the credential"
+        required: false
+        default: "-"
+        type: string
+      oauth-client-id:
+        description: "Tailscale federated identity client ID (not a secret)"
+        required: true
+        type: string
+      audience:
+        description: "Audience the federated identity expects, e.g. api.tailscale.com/<client id> (not a secret)"
+        required: true
+        type: string
+      policy-file:
+        description: "Path to the HuJSON policy file, relative to the repository root"
+        required: false
+        default: "policy.hujson"
+        type: string
+      action:
+        description: "'test', 'apply', or '' to test on pull requests and apply on pushes to the default branch"
+        required: false
+        default: ""
+        type: string
+      runner:
+        description: "Runner label"
+        required: false
+        default: "ubuntu-latest"
+        type: string
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        default: 10
+        type: number
+      cancel-in-progress:
+        description: "Cancel previous in-progress runs for same ref"
+        required: false
+        default: false
+        type: boolean
+      concurrency-suffix:
+        description: "Optional suffix to distinguish concurrency groups when this reusable workflow is called multiple times in one workflow"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  acl:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    concurrency:
+      group: ${{ inputs.concurrency-suffix != '' && format('{0}:{1}:{2}:{3}', github.workflow, github.repository, github.ref, inputs.concurrency-suffix) || format('{0}:{1}:{2}', github.workflow, github.repository, github.ref) }}
+      cancel-in-progress: ${{ inputs.cancel-in-progress }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Resolve action
+        id: resolve
+        env:
+          REQUESTED: ${{ inputs.action }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          POLICY_FILE: ${{ inputs.policy-file }}
+        run: |
+          set -euo pipefail
+
+          case "$REQUESTED" in
+            test|apply)
+              resolved="$REQUESTED"
+              ;;
+            "")
+              # Applying only from the default branch keeps a merge the single
+              # way the tailnet changes. Everything else validates and stops.
+              if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/$DEFAULT_BRANCH" ]; then
+                resolved="apply"
+              else
+                resolved="test"
+              fi
+              ;;
+            *)
+              echo "::error title=Invalid action::action must be 'test', 'apply', or '' for automatic selection, got '$REQUESTED'." >&2
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$POLICY_FILE" ]; then
+            echo "::error title=Policy file not found::'$POLICY_FILE' does not exist in this repository. Set the policy-file input to its path." >&2
+            exit 1
+          fi
+
+          echo "action=$resolved" >> "$GITHUB_OUTPUT"
+          echo "Resolved action: $resolved (policy file: $POLICY_FILE)"
+
+      - name: Run Tailscale ACL ${{ steps.resolve.outputs.action }}
+        uses: tailscale/gitops-acl-action@5a4a17f5708e9bf96f4ee915a95e9f83c2eebe1a # v1.5.2
+        with:
+          oauth-client-id: ${{ inputs.oauth-client-id }}
+          audience: ${{ inputs.audience }}
+          tailnet: ${{ inputs.tailnet }}
+          policy-file: ${{ inputs.policy-file }}
+          action: ${{ steps.resolve.outputs.action }}
+
+      - name: Summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "### Tailscale ACL summary"
+            echo "- action: \`${{ steps.resolve.outputs.action || 'unresolved' }}\`"
+            echo "- policy-file: \`${{ inputs.policy-file }}\`"
+            echo "- tailnet: \`${{ inputs.tailnet }}\`"
+            echo "- runner: \`${{ inputs.runner }}\`"
+            echo "- timeout-minutes: \`${{ inputs.timeout-minutes }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .fallow/
 .worktrees/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -147,6 +147,40 @@ jobs:
 
 Artifact mode requires `artifact-run-id`, `artifact-name`, and `artifact-digest` together. Existing callers may omit all three fields for source-only dispatches. The GitHub App used by the infra repository must have Actions read access to the source repository so infra can download the exact artifact.
 
+### Tailscale ACL
+
+Validates a tailnet policy file and runs the policy's own ACL tests on pull requests, then applies it on merge to the default branch.
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  acl:
+    uses: matt-riley/matt-riley-ci/.github/workflows/tailscale-acl.yml@v2
+    with:
+      oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+      audience: ${{ vars.TS_AUDIENCE }}
+      tailnet: "-"
+      policy-file: policy.hujson
+      action: ""
+      runner: ubuntu-latest
+      timeout-minutes: 10
+      cancel-in-progress: false
+      concurrency-suffix: ""
+```
+
+This workflow takes **no secrets**. Authentication is [workload identity federation][ts-wif]: the runner mints a short-lived OIDC token and Tailscale exchanges it for a short-lived API token, so nothing long-lived is stored. The client ID and audience are not sensitive, which is why they are inputs rather than secrets — pass them as repository variables. The caller must grant `id-token: write`.
+
+Create the federated identity in the Tailscale admin console with issuer `https://token.actions.githubusercontent.com` and a subject restricted to the calling repository, for example `repo:matt-riley/infra:*`. The audience is `api.tailscale.com/<client id>`.
+
+Leave `action` empty to test on pull requests and apply on pushes to the default branch. Set it to `test` or `apply` to force one — `test` is the right choice when something else, such as Terraform, is the applier, since two owners of the same policy will overwrite each other.
+
+Policy files contain user and group identifiers, so the calling repository should be private.
+
+[ts-wif]: https://tailscale.com/docs/features/workload-identity-federation
+
 ### Neovim Format
 
 Runs StyLua with a pinned release.

--- a/tests/contract_workflow_registration_test.py
+++ b/tests/contract_workflow_registration_test.py
@@ -9,6 +9,7 @@ class ContractWorkflowRegistrationTest(unittest.TestCase):
         self.assertIn("tests/request_infra_deploy_contract_test.py", workflow)
         self.assertIn("tests/contract_workflow_registration_test.py", workflow)
         self.assertIn("tests/ci_cache_contract_test.py", workflow)
+        self.assertIn("tests/tailscale_acl_contract_test.py", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/tailscale_acl_contract_test.py
+++ b/tests/tailscale_acl_contract_test.py
@@ -1,0 +1,108 @@
+import pathlib
+import re
+import unittest
+
+import yaml
+
+WORKFLOW = pathlib.Path(".github/workflows/tailscale-acl.yml")
+
+
+class TailscaleAclContractTest(unittest.TestCase):
+    def setUp(self):
+        data = yaml.safe_load(WORKFLOW.read_text())
+        self.data = data
+        # PyYAML reads the bare key "on" as boolean True under YAML 1.1.
+        self.call = data.get("on", data.get(True))["workflow_call"]
+        self.inputs = self.call["inputs"]
+        self.job = data["jobs"]["acl"]
+        self.steps = self.job["steps"]
+
+    def _step(self, name_fragment):
+        for step in self.steps:
+            if name_fragment in step.get("name", ""):
+                return step
+        self.fail(f"Missing workflow step containing: {name_fragment}")
+
+    # Workload identity federation is the entire reason this workflow can take
+    # no secrets. A secrets block reappearing means someone reintroduced a
+    # long-lived credential.
+    def test_takes_no_secrets(self):
+        self.assertNotIn("secrets", self.call)
+        self.assertNotIn("secrets.", WORKFLOW.read_text())
+
+    def test_credentials_are_plain_inputs(self):
+        for name in ("oauth-client-id", "audience"):
+            with self.subTest(name=name):
+                self.assertIn(name, self.inputs)
+                self.assertTrue(self.inputs[name]["required"])
+                self.assertEqual(self.inputs[name]["type"], "string")
+
+        acl_step = self._step("Run Tailscale ACL")
+        self.assertEqual(
+            acl_step["with"]["oauth-client-id"], "${{ inputs.oauth-client-id }}"
+        )
+        self.assertEqual(acl_step["with"]["audience"], "${{ inputs.audience }}")
+        self.assertNotIn("oauth-secret", acl_step["with"])
+        self.assertNotIn("api-key", acl_step["with"])
+
+    def test_job_can_mint_an_oidc_token(self):
+        self.assertEqual(self.job["permissions"]["id-token"], "write")
+        self.assertEqual(self.job["permissions"]["contents"], "read")
+
+    def test_third_party_actions_are_sha_pinned(self):
+        for step in self.steps:
+            uses = step.get("uses")
+            if not uses or uses.startswith("./"):
+                continue
+            with self.subTest(uses=uses):
+                self.assertRegex(uses, r"^[^@]+@[0-9a-f]{40}$")
+
+    def test_policy_file_defaults_to_the_documented_name(self):
+        self.assertEqual(self.inputs["policy-file"]["default"], "policy.hujson")
+        self.assertFalse(self.inputs["policy-file"]["required"])
+
+    def test_action_input_defaults_to_automatic_selection(self):
+        self.assertEqual(self.inputs["action"]["default"], "")
+        self.assertFalse(self.inputs["action"]["required"])
+
+    # Auto-selection must never apply from anywhere but a default-branch push,
+    # or a pull request could mutate the tailnet before review.
+    def test_apply_is_reachable_only_from_a_default_branch_push(self):
+        resolve = self._step("Resolve action")["run"]
+
+        self.assertIn('if [ "$EVENT_NAME" = "push" ]', resolve)
+        self.assertIn('[ "$REF" = "refs/heads/$DEFAULT_BRANCH" ]', resolve)
+        # The apply assignment sits inside that guard, and the fallback is test.
+        guard = re.search(
+            r'if \[ "\$EVENT_NAME" = "push" \].*?\n(.*?)\n\s*fi', resolve, re.S
+        )
+        self.assertIsNotNone(guard, "expected the push/default-branch guard")
+        self.assertIn('resolved="apply"', guard.group(1))
+        self.assertIn('resolved="test"', guard.group(1))
+
+    def test_invalid_action_fails_the_run(self):
+        resolve = self._step("Resolve action")["run"]
+
+        self.assertIn("case \"$REQUESTED\" in", resolve)
+        self.assertIn("test|apply)", resolve)
+        self.assertIn("Invalid action", resolve)
+
+    def test_missing_policy_file_fails_before_calling_tailscale(self):
+        resolve = self._step("Resolve action")["run"]
+
+        self.assertIn('if [ ! -f "$POLICY_FILE" ]', resolve)
+        names = [step.get("name", "") for step in self.steps]
+        self.assertLess(
+            names.index("Resolve action"),
+            next(i for i, n in enumerate(names) if n.startswith("Run Tailscale ACL")),
+        )
+
+    def test_is_documented_in_the_readme(self):
+        readme = pathlib.Path("README.md").read_text()
+
+        self.assertIn("tailscale-acl.yml", readme)
+        self.assertIn("### Tailscale ACL", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a reusable workflow for GitOps management of a tailnet policy file, following [Tailscale's GitOps guide](https://tailscale.com/docs/integrations/github/gitops) — validate and run the policy's own ACL tests on pull requests, apply on merge to the default branch.

## Why it takes no secrets

Tailscale's own example puts `TS_OAUTH_ID`, `TS_AUDIENCE`, and `TS_TAILNET` in `secrets:`. None of the three is sensitive. Because [workload identity federation](https://tailscale.com/docs/features/workload-identity-federation) lets the runner mint its own OIDC token and exchange it for a short-lived API token, there is no credential to hide — so all three are plain `inputs:` and the workflow declares no `secrets:` block at all. Callers pass them as repository variables and grant `id-token: write`.

A contract test asserts the `secrets:` block stays absent, so a long-lived credential cannot quietly reappear.

## Behaviour

`action` defaults to empty, which resolves to `test` on pull requests and `apply` only on a push to the default branch. Callers set it explicitly to `test` when something else owns the policy — two appliers of one policy file overwrite each other.

The workflow fails early with an actionable message if the policy file is missing, before making any call to Tailscale.

## Pinning

`tailscale/gitops-acl-action` is pinned to `5a4a17f` (v1.5.2). Tailscale's examples use the floating `@v1`, which `validate-workflows.yml` rejects. I verified against `action.yml` at that exact SHA that `oauth-client-id` + `audience` is a supported auth path and that `policy-file`, `tailnet`, and `action` are the correct input names.

## Verification

- `tests/tailscale_acl_contract_test.py` — 10 new contract tests, registered in `contract-tests.yml` and in the registration test
- full contract suite passes locally
- the repo's own workflow validator passes (21 files)
- `actionlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)