### PR TITLE
feat!: authenticate Cloudflare Pages deploys by OIDC

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -42,10 +42,15 @@ on:
         required: false
         default: 15
         type: number
+      oidc-audience:
+        description: "Audience claim to request in the GitHub OIDC token, matched by the Cloudflare token's OIDC condition"
+        required: false
+        default: ""
+        type: string
     secrets:
       CLOUDFLARE_API_TOKEN:
-        description: "Cloudflare API token with Pages edit permission"
-        required: true
+        description: "Cloudflare API token with Pages edit permission. Omit to authenticate by OIDC instead."
+        required: false
       CLOUDFLARE_ACCOUNT_ID:
         description: "Cloudflare account ID"
         required: true
@@ -57,6 +62,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -95,10 +101,51 @@ jobs:
           esac
         working-directory: ${{ inputs.working-directory }}
 
+      - name: Resolve Cloudflare API token
+        id: cloudflare-auth
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          OIDC_AUDIENCE: ${{ inputs.oidc-audience }}
+        run: |
+          set -euo pipefail
+
+          # Fall back to the long-lived secret while OIDC is being rolled out.
+          # Once the caller stops passing it, the OIDC path is the only path.
+          if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::add-mask::$CLOUDFLARE_API_TOKEN"
+            echo "token=$CLOUDFLARE_API_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "mode=secret" >> "$GITHUB_OUTPUT"
+            echo "Using the CLOUDFLARE_API_TOKEN secret."
+            exit 0
+          fi
+
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error title=No Cloudflare credential::CLOUDFLARE_API_TOKEN was not supplied and no OIDC token is available. Grant 'id-token: write' in the calling workflow, or pass the secret." >&2
+            exit 1
+          fi
+
+          audience="${OIDC_AUDIENCE:-}"
+          if [ -z "$audience" ]; then
+            audience="https://github.com/${GITHUB_REPOSITORY_OWNER}"
+          fi
+
+          github_jwt="$(curl -sS -f -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}" | jq -re .value)"
+
+          cloudflare_resp="$(curl -sS -f -X POST "https://api.cloudflare.com/client/v4/oauth/token" \
+            -H "Content-Type: application/json" \
+            -d "$(printf '{"grant_type":"urn:ietf:params:oauth:grant-type:token-exchange","subject_token":"%s","subject_token_type":"urn:ietf:params:oauth:token-type:jwt"}' "$github_jwt")")"
+
+          cf_token="$(jq -re '.result.access_token' <<< "$cloudflare_resp")"
+          echo "::add-mask::$cf_token"
+          echo "token=$cf_token" >> "$GITHUB_OUTPUT"
+          echo "mode=oidc" >> "$GITHUB_OUTPUT"
+          echo "Exchanged the GitHub OIDC token for a short-lived Cloudflare token."
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ steps.cloudflare-auth.outputs.token }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ${{ inputs.deploy-directory }} --project-name=${{ inputs.project-name }}
           workingDirectory: ${{ inputs.working-directory }}
@@ -108,6 +155,7 @@ jobs:
         run: |
           {
             echo "### Cloudflare Pages Deploy summary"
+            echo "- auth: \`${{ steps.cloudflare-auth.outputs.mode || 'unresolved' }}\`"
             echo "- runner: \`${{ inputs.runner }}\`"
             echo "- timeout-minutes: \`${{ inputs.timeout-minutes }}\`"
             echo "- project-name: \`${{ inputs.project-name }}\`"

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -39,6 +39,7 @@ jobs:
           python -m unittest tests/request_infra_deploy_contract_test.py
           python -m unittest tests/contract_workflow_registration_test.py
           python -m unittest tests/ci_cache_contract_test.py
+          python -m unittest tests/cloudflare_pages_oidc_contract_test.py
 
   go-contract:
     uses: ./.github/workflows/ci.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .fallow/
 .worktrees/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -94,9 +94,13 @@ Aube reads supported lockfiles in place (`aube-lock.yaml`, `package-lock.json`, 
 Builds a Node-based project and deploys it to Cloudflare Pages.
 
 ```yaml
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
-    uses: matt-riley/matt-riley-ci/.github/workflows/cloudflare-pages-deploy.yml@v1
+    uses: matt-riley/matt-riley-ci/.github/workflows/cloudflare-pages-deploy.yml@v3
     with:
       project-name: my-pages-project
       deploy-directory: dist
@@ -106,10 +110,23 @@ jobs:
       working-directory: .
       runner: ubuntu-latest
       timeout-minutes: 15
+      oidc-audience: ""
     secrets:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 ```
+
+**Breaking in v3.** The job now requests `id-token: write`, and a reusable workflow cannot hold a permission its caller has not granted — so every caller must add the `permissions` block above, including callers that keep using the API token. Callers pinned to `@v1` or `@v2` are unaffected until they bump.
+
+`CLOUDFLARE_API_TOKEN` is now optional. Omit it and the workflow exchanges the runner's GitHub OIDC token for a short-lived Cloudflare API token, so no long-lived token is stored:
+
+```yaml
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+Pass it and that value is used unchanged, which lets a repository migrate on its own schedule. To use OIDC, create a Cloudflare API token with a Gateway condition on the `sub` claim matching the calling repository (for example `repo:matt-riley/my-app`). `oidc-audience` defaults to `https://github.com/<owner>`; set it if the Cloudflare token expects a different audience.
+
+`CLOUDFLARE_ACCOUNT_ID` stays required — OIDC replaces the credential, not the account selector.
 
 ### Request Infra Deploy
 

--- a/tests/cloudflare_pages_oidc_contract_test.py
+++ b/tests/cloudflare_pages_oidc_contract_test.py
@@ -1,0 +1,90 @@
+import pathlib
+import unittest
+
+import yaml
+
+WORKFLOW = pathlib.Path(".github/workflows/cloudflare-pages-deploy.yml")
+
+
+class CloudflarePagesOidcContractTest(unittest.TestCase):
+    def setUp(self):
+        data = yaml.safe_load(WORKFLOW.read_text())
+        # PyYAML reads the bare key "on" as boolean True under YAML 1.1.
+        self.call = data.get("on", data.get(True))["workflow_call"]
+        self.job = data["jobs"]["deploy"]
+        self.steps = self.job["steps"]
+
+    def _step(self, name):
+        for step in self.steps:
+            if step.get("name") == name:
+                return step
+        self.fail(f"Missing workflow step: {name}")
+
+    def test_job_can_mint_an_oidc_token(self):
+        self.assertEqual(self.job["permissions"]["id-token"], "write")
+
+    # The whole point of the migration: a caller can deploy without holding a
+    # long-lived Cloudflare token.
+    def test_api_token_secret_is_optional(self):
+        self.assertFalse(self.call["secrets"]["CLOUDFLARE_API_TOKEN"]["required"])
+
+    # OIDC swaps the credential, not the account selector.
+    def test_account_id_stays_required(self):
+        self.assertTrue(self.call["secrets"]["CLOUDFLARE_ACCOUNT_ID"]["required"])
+
+    def test_deploy_consumes_the_resolved_token_not_the_secret(self):
+        deploy = self._step("Deploy to Cloudflare Pages")
+
+        self.assertEqual(
+            deploy["with"]["apiToken"], "${{ steps.cloudflare-auth.outputs.token }}"
+        )
+        self.assertEqual(
+            deploy["with"]["accountId"], "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
+        )
+
+    def test_secret_path_short_circuits_before_the_exchange(self):
+        resolve = self._step("Resolve Cloudflare API token")["run"]
+
+        self.assertIn('if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]', resolve)
+        self.assertIn('mode=secret', resolve)
+        # The fallback returns before any network call is made.
+        self.assertLess(resolve.index("exit 0"), resolve.index("oauth/token"))
+
+    def test_exchange_uses_the_token_exchange_grant(self):
+        resolve = self._step("Resolve Cloudflare API token")["run"]
+
+        self.assertIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", resolve)
+        self.assertIn(
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+            resolve,
+        )
+        self.assertIn("https://api.cloudflare.com/client/v4/oauth/token", resolve)
+        self.assertIn(".result.access_token", resolve)
+
+    # Both branches produce a credential that must never reach the log.
+    def test_both_credentials_are_masked(self):
+        resolve = self._step("Resolve Cloudflare API token")["run"]
+
+        self.assertEqual(resolve.count("::add-mask::"), 2)
+
+    def test_missing_credential_fails_with_actionable_guidance(self):
+        resolve = self._step("Resolve Cloudflare API token")["run"]
+
+        self.assertIn('if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]', resolve)
+        self.assertIn("id-token: write", resolve)
+
+    def test_audience_defaults_to_the_repository_owner(self):
+        resolve = self._step("Resolve Cloudflare API token")["run"]
+
+        self.assertEqual(self.call["inputs"]["oidc-audience"]["default"], "")
+        self.assertIn('https://github.com/${GITHUB_REPOSITORY_OWNER}', resolve)
+
+    def test_readme_documents_the_breaking_permission(self):
+        readme = pathlib.Path("README.md").read_text()
+
+        self.assertIn("Breaking in v3", readme)
+        self.assertIn("id-token: write", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract_workflow_registration_test.py
+++ b/tests/contract_workflow_registration_test.py
@@ -9,6 +9,7 @@ class ContractWorkflowRegistrationTest(unittest.TestCase):
         self.assertIn("tests/request_infra_deploy_contract_test.py", workflow)
         self.assertIn("tests/contract_workflow_registration_test.py", workflow)
         self.assertIn("tests/ci_cache_contract_test.py", workflow)
+        self.assertIn("tests/cloudflare_pages_oidc_contract_test.py", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> ⚠️ **Breaking change — needs a major release (v3).** See below.

`infra` already exchanges its GitHub OIDC token for a short-lived Cloudflare API token (`terraform-plan.yml`, `terraform-apply.yml`), while this shared workflow still required a long-lived one. Same pattern, third provider — worth making the house convention instead of something infra does on its own.

## What changes

`CLOUDFLARE_API_TOKEN` becomes **optional**:

- **omitted** → the workflow exchanges the runner's GitHub OIDC token for a short-lived Cloudflare token, scoped by the Cloudflare token's `sub` condition. Nothing long-lived is stored.
- **passed** → that value is used unchanged, so repositories migrate on their own schedule.

The exchange mirrors infra's implementation, including the `urn:ietf:params:oauth:grant-type:token-exchange` grant and the `CLOUDFLARE_OIDC_AUDIENCE` default of `https://github.com/<owner>`, now exposed as the `oidc-audience` input.

`CLOUDFLARE_ACCOUNT_ID` stays required — OIDC replaces the credential, not the account selector.

## Why this is breaking

The deploy job now requests `id-token: write`. A reusable workflow **cannot hold a permission its caller has not granted**, so the run fails at validation time if the caller is silent. That means every caller must add:

```yaml
permissions:
  contents: read
  id-token: write
```

**including callers that keep passing `CLOUDFLARE_API_TOKEN`.** There is no way to make this conditional — `permissions` cannot take expressions. Callers pinned to `@v1` or `@v2` are unaffected until they bump.

The commit is `feat!` with a `BREAKING CHANGE:` trailer so release-please cuts v3. The README example is already updated to `@v3`.

## Verification

- `tests/cloudflare_pages_oidc_contract_test.py` — 10 new contract tests covering both auth branches, masking of both credentials, the short-circuit before any network call, and the actionable error when neither credential is available
- full contract suite passes locally (16 tests)
- workflow validator and `actionlint` clean

## Worth a look

I could not verify the OIDC path end to end without a Cloudflare token carrying a `sub` condition — the fallback branch is what runs today. Recommend rolling out on one app repo before deleting any `CLOUDFLARE_API_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)