### PR TITLE
docs: stop the changelog @-mentioning GitHub users v1 and v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* the deploy job requests `id-token: write`, and a reusable workflow cannot hold a permission its caller has not granted. Every caller must add `permissions: id-token: write`, including callers that keep passing CLOUDFLARE_API_TOKEN. Callers pinned to @v1 or @v2 are unaffected until they bump.
+* the deploy job requests `id-token: write`, and a reusable workflow cannot hold a permission its caller has not granted. Every caller must add `permissions: id-token: write`, including callers that keep passing CLOUDFLARE_API_TOKEN. Callers pinned to `@v1` or `@v2` are unaffected until they bump.
 
 ### Features
 


### PR DESCRIPTION
The 3.0.0 breaking-change note read *"Callers pinned to @v1 or @v2"* with bare `@`s. release-please copies the commit body verbatim into `CHANGELOG.md` and the release notes, where GitHub resolved both as **user mentions** — crediting the accounts [`v1`](https://github.com/v1) and [`v2`](https://github.com/v2) as contributors to the release. They have nothing to do with this repository.

Backticked so they render as the version refs they are.

**The v3.0.0 release notes are already corrected in place** — that's the page that actually displayed the contributors, and it isn't regenerated from the changelog.

My commit message in #98 caused this. Version refs need backticks anywhere release-please might republish them, since the commit body becomes rendered Markdown on github.com.

Checked every other release: `v3.0.0` was the only one affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)