### PR TITLE
fix: publish the floating major tag with a token that can

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -41,6 +41,7 @@ jobs:
           python -m unittest tests/ci_cache_contract_test.py
           python -m unittest tests/tailscale_acl_contract_test.py
           python -m unittest tests/cloudflare_pages_oidc_contract_test.py
+          python -m unittest tests/major_tag_publish_contract_test.py
 
   go-contract:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/repository-release-please.yml
+++ b/.github/workflows/repository-release-please.yml
@@ -26,14 +26,23 @@ jobs:
     permissions:
       contents: write
     steps:
+      # GITHUB_TOKEN is a GitHub App token, and GitHub refuses to let an App
+      # token create or update a ref carrying .github/workflows content without
+      # `workflows` permission — which is not a grantable scope in the
+      # `permissions:` block above, so it cannot be fixed there. This repository
+      # is nothing but workflows, so every major tag trips it. RELEASE_TAG_TOKEN
+      # is a PAT or App token that does hold `workflows`.
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: true
+          token: ${{ secrets.RELEASE_TAG_TOKEN || github.token }}
 
       - name: Move major tag
         env:
           TAG_NAME: ${{ needs.release.outputs.tag_name }}
+          HAS_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN != '' }}
         run: |
           set -euo pipefail
 
@@ -47,7 +56,15 @@ jobs:
 
           git fetch --force --tags origin
           target_sha="$(git rev-list -n 1 "refs/tags/$TAG_NAME")"
-          current_sha="$(git ls-remote --tags origin "refs/tags/$major_tag" | awk '{print $1}')"
+
+          # ls-remote prints a second "^{}" line for annotated tags, so take the
+          # dereferenced value when present and never let two SHAs reach the
+          # comparison below.
+          current_sha="$(
+            git ls-remote --tags origin "refs/tags/$major_tag" "refs/tags/$major_tag^{}" \
+              | sed -n 's/^\([0-9a-f]\{40\}\).*/\1/p' \
+              | tail -n 1
+          )"
 
           if [ -z "$target_sha" ]; then
             echo "Could not resolve release tag $TAG_NAME" >&2
@@ -60,15 +77,38 @@ jobs:
           fi
 
           git tag -f "$major_tag" "$target_sha"
-          git push origin "refs/tags/$major_tag" --force
+
+          if git push origin "refs/tags/$major_tag" --force; then
+            echo "$major_tag now points at $TAG_NAME"
+            exit 0
+          fi
+
+          if [ "$HAS_TAG_TOKEN" != "true" ]; then
+            echo "::error title=Cannot publish $major_tag::Pushing $major_tag was rejected, and RELEASE_TAG_TOKEN is not set. The default GITHUB_TOKEN is a GitHub App token, which cannot create or update a ref containing .github/workflows without 'workflows' permission — a scope the permissions: block cannot grant. Add a RELEASE_TAG_TOKEN secret (PAT or App token with workflows write) and re-run. Until then callers pinning @$major_tag will not resolve." >&2
+          else
+            echo "::error title=Cannot publish $major_tag::Pushing $major_tag was rejected even with RELEASE_TAG_TOKEN set. Check that the token still has 'workflows' write and has not expired." >&2
+          fi
+          exit 1
 
       - name: Summary
         if: ${{ always() }}
         env:
           TAG_NAME: ${{ needs.release.outputs.tag_name }}
+          HAS_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN != '' }}
         run: |
+          major_tag="${TAG_NAME%%.*}"
+
+          # Report what callers can actually pin, not what we intended to push.
+          if git ls-remote --exit-code --tags origin "refs/tags/$major_tag" >/dev/null 2>&1; then
+            published="yes"
+          else
+            published="no"
+          fi
+
           {
             echo "### Floating major tag summary"
             echo "- release tag: \`$TAG_NAME\`"
-            echo "- floating tag: \`${TAG_NAME%%.*}\`"
+            echo "- floating tag: \`$major_tag\`"
+            echo "- published: $published"
+            echo "- RELEASE_TAG_TOKEN configured: $HAS_TAG_TOKEN"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Reusable GitHub Actions workflows for Matt Riley repositories.
 - Use `@v1.x.y` for fully pinned workflow behavior.
 - Breaking changes are released under a new major tag (for example `@v2`).
 
+Write version refs in backticks in commit bodies. release-please republishes
+those bodies verbatim into `CHANGELOG.md` and the release notes, where a bare
+`@v1` resolves as a mention of the GitHub user of that name.
+
+### Publishing the floating major tag
+
+`repository-release-please.yml` moves the floating `vN` tag after each release.
+That push needs a **`RELEASE_TAG_TOKEN`** repository secret — a PAT or GitHub
+App token with **workflows: write**.
+
+The default `GITHUB_TOKEN` cannot do it. It is a GitHub App token, and GitHub
+refuses to let an App token create or update a ref containing
+`.github/workflows` content without `workflows` permission. That is not a
+grantable scope in a workflow's `permissions:` block, so no amount of
+permission tuning fixes it, and this repository is nothing but workflows.
+
+Without the secret the release itself still succeeds and `vN.n.n` is published;
+only the floating `vN` tag is missing, so callers pinning `@vN` fail to resolve.
+The job fails loudly and says so rather than passing silently.
+
 ## Workflows
 
 ### Universal CI

--- a/tests/contract_workflow_registration_test.py
+++ b/tests/contract_workflow_registration_test.py
@@ -11,6 +11,7 @@ class ContractWorkflowRegistrationTest(unittest.TestCase):
         self.assertIn("tests/ci_cache_contract_test.py", workflow)
         self.assertIn("tests/tailscale_acl_contract_test.py", workflow)
         self.assertIn("tests/cloudflare_pages_oidc_contract_test.py", workflow)
+        self.assertIn("tests/major_tag_publish_contract_test.py", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/major_tag_publish_contract_test.py
+++ b/tests/major_tag_publish_contract_test.py
@@ -1,0 +1,72 @@
+import pathlib
+import unittest
+
+import yaml
+
+WORKFLOW = pathlib.Path(".github/workflows/repository-release-please.yml")
+
+
+class MajorTagPublishContractTest(unittest.TestCase):
+    def setUp(self):
+        data = yaml.safe_load(WORKFLOW.read_text())
+        self.job = data["jobs"]["move-major-tag"]
+        self.steps = self.job["steps"]
+
+    def _step(self, name):
+        for step in self.steps:
+            if step.get("name") == name:
+                return step
+        self.fail(f"Missing workflow step: {name}")
+
+    # The default GITHUB_TOKEN is a GitHub App token, which GitHub refuses to
+    # let create or update a ref carrying .github/workflows content. Every tag
+    # in this repository carries exactly that, so the checkout has to be able to
+    # pick up a token that holds `workflows`.
+    def test_checkout_prefers_the_release_tag_token(self):
+        checkout = self._step("Checkout")
+
+        self.assertEqual(
+            checkout["with"]["token"],
+            "${{ secrets.RELEASE_TAG_TOKEN || github.token }}",
+        )
+        self.assertEqual(checkout["with"]["persist-credentials"], True)
+        self.assertEqual(checkout["with"]["fetch-depth"], 0)
+
+    # `workflows` is not a grantable scope, so nobody should "fix" a future
+    # failure by adding it here and assuming it works.
+    def test_permissions_do_not_pretend_to_grant_workflows(self):
+        self.assertNotIn("workflows", self.job.get("permissions", {}))
+
+    def test_push_failure_is_reported_not_swallowed(self):
+        run = self._step("Move major tag")["run"]
+
+        self.assertIn("if git push origin", run)
+        self.assertIn("::error title=Cannot publish", run)
+        self.assertIn("RELEASE_TAG_TOKEN", run)
+        # A rejected push must fail the job; a missing floating tag silently
+        # breaks every caller pinning @vN.
+        self.assertIn("exit 1", run)
+
+    # ls-remote emits a second "^{}" line for annotated tags. Two SHAs reaching
+    # the equality check would make it never match and force-push every time.
+    def test_idempotence_check_handles_annotated_tags(self):
+        run = self._step("Move major tag")["run"]
+
+        self.assertIn('"refs/tags/$major_tag^{}"', run)
+        self.assertIn("tail -n 1", run)
+
+    def test_summary_reports_what_was_actually_published(self):
+        run = self._step("Summary")["run"]
+
+        self.assertIn("git ls-remote --exit-code --tags origin", run)
+        self.assertIn("published:", run)
+
+    def test_readme_documents_the_secret(self):
+        readme = pathlib.Path("README.md").read_text()
+
+        self.assertIn("RELEASE_TAG_TOKEN", readme)
+        self.assertIn("workflows: write", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Releasing `3.0.0` published `v3.0.0` but **not** the floating `v3` tag, so the README's `@v3` example currently doesn't resolve. The push was rejected:

```
! [remote rejected] v3 -> v3 (refusing to allow a GitHub App to create or update
  workflow `.github/workflows/cloudflare-pages-deploy.yml` without `workflows` permission)
```

## Why no permission tweak fixes this

`GITHUB_TOKEN` is a GitHub App token, and GitHub won't let an App token create or update a ref carrying `.github/workflows` content without `workflows` permission. **`workflows` is not a grantable scope** in a workflow's `permissions:` block — the list is `actions`, `contents`, `id-token`, and so on. So the job could never have worked in this repository, which is nothing but workflows. It needs a different token.

This is **latent, not caused by 3.0.0** — it's just the first release that had to create a *new* major ref rather than move an existing one.

## Changes

- push credential comes from an optional **`RELEASE_TAG_TOKEN`** secret (PAT or App token with `workflows: write`), falling back to `GITHUB_TOKEN` so nothing breaks before the secret exists
- a rejected push now **fails with an actionable message** naming the cause, instead of leaving a release whose floating tag silently doesn't exist
- the summary reports whether the tag is *actually resolvable*, rather than echoing the name we intended to publish
- **unrelated bug spotted while in here:** the idempotence check took `ls-remote | awk '{print $1}'`, which emits two SHAs for an annotated tag (`v2` and `v2^{}`). Two SHAs could never equal one, so it would force-push on every release. Now takes the dereferenced value.

## Verification

- `tests/major_tag_publish_contract_test.py` — 6 tests, **5 fail against current `main`**. One deliberately passes on both: it asserts nobody ever "fixes" a future failure by adding a `workflows` permission that doesn't exist.
- extraction logic unit-checked against lightweight tag, annotated tag, and missing tag
- both `run` blocks pass `bash -n`; `actionlint` clean; validator passes 21 files; full contract suite 32 tests green

## You still need to do two things

1. **Add the `RELEASE_TAG_TOKEN` secret.** Without it this PR changes nothing at release time — the fallback is still `GITHUB_TOKEN`, which will still be rejected. It'll just fail loudly and tell you why.
2. **`v3` is still missing right now.** This fixes future releases, not the existing gap. Creating it is a one-off: `git tag v3 v3.0.0 && git push origin v3` from a machine with a user credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)